### PR TITLE
update deps

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,10 +36,11 @@ package_dir =
 # add your package requirements here
 install_requires =
     numpy
+    scipy
     magicgui
     qtpy
     pandas
-    skimage
+    scikit-image
 
 [options.extras_require]
 testing =


### PR DESCRIPTION
Howdie Jay,

just doing some plugin tests and noticed a failure to install this one.  scikit-image needs to be specified as `scikit-image` in your dependencies (even though the import is `skimage`)